### PR TITLE
add copy_type and delete_after_copy options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+post_backup.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 post_backup.sh
+config.json

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Sure, there are fancier solutions like SD card muxers (like the [USB-SD-Mux](htt
 - [Auto Start on boot (SystemD service)](#auto-start-on-boot-systemd-service)
 - [Callback on backup completion](#callback-on-backup-completion)
 - [Configuration](#configuration)
-- [Log Management](#log-management)
 - [Syncing to Your Computer](#syncing-to-your-computer)
 - [Final setup](#final-setup)
 

--- a/README.md
+++ b/README.md
@@ -22,13 +22,25 @@ Instead of fancy expensive hardware, here's what I came up with:
 
 Sure, there are fancier solutions like SD card muxers (like the [USB-SD-Mux](https://linux-automation.com/en/products/usb-sd-mux-fast.html)), but they're expensive and probably overkill. Plus, who knows if they'd even work with a CPAP?
 
-### Hardware Requirements
+## Table of Contents
+
+- [Hardware Requirements](#hardware-requirements)
+- [Setting Things Up](#setting-things-up)
+- [Auto Start on boot (SystemD service)](#auto-start-on-boot-systemd-service)
+- [Callback on backup completion](#callback-on-backup-completion)
+- [Configuration](#configuration)
+- [Log Management](#log-management)
+- [Syncing to Your Computer](#syncing-to-your-computer)
+- [Final setup](#final-setup)
+
+
+## Hardware Requirements
 
 - [Orange Pi Zero 2W 1GB](https://www.aliexpress.com/item/1005005979335218.html) (or any Linux-capable single-board computer)
 - A USB SD card reader (I use [Vava USB-C hub](https://www.vava.com/products/vava-hub-p8-ii))
 - MicroSD card for the Orange Pi (I recommend [SanDisk Ultra A1 SDSQUAB-064G-GH3MA](https://www.amazon.co.jp/dp/B0CH2XQN3P)) 
 
-### Flow 
+## Flow 
 
 ```mermaid
 sequenceDiagram

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ sudo systemctl enable --now cpapshare.service
 The `cpapshare.rb` also has a mechanism to trigger some callback script after the backup is done. You simply need to have a file `post_backup.sh` in the same directory as the cpapshare.rb file.  
 Check example [post_backup.example.sh](./post_backup.example.sh), I'm using it to send a notification to [ntfy.sh](http://ntfy.sh), so I get notified on my phone when the backup is done. Make sure the script is executable.
 
-## Configuration
+## Configuration (optional)
 
 CPAPShare can be configured using a `config.json` file in the project directory. The configuration is reloaded automatically each time an SD card is inserted, so no service restart is needed when changing settings.
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ This adds a polkit config allowing members of the `sudo` group to mount devices.
 The project includes a SystemD service file ([cpapshare.service](./cpapshare.service)). To enable it:
 ```shell
 sudo cp cpapshare.service /etc/systemd/system/cpapshare.service
-systemctl enable cpapshare.service
+sudo systemctl enable cpapshare.service
+sudo systemctl restart cpapshare.service
+sudo systemctl status cpapshare.service
 ```
 
 ## Callback on backup completion

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ git clone https://github.com/pcboy/cpapshare ~/cpapshare
 7. If you can't mount devices as user `armbian`, that means you are missing the polkit policy. In that case do:
 
 ```shell
-sudo cpapshare.rb --install
+sudo ./cpapshare.rb --install
 ```
 
 This adds a polkit config allowing members of the `sudo` group to mount devices.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,41 @@ Controls whether to delete the DATALOG directory from the SD card after successf
 
 **Note:** If no `config.json` file exists, the script will use the defaults (`copy_type: "raw"`, `delete_after_copy: false`).
 
+## Log Management
+
+CPAPShare writes logs to `/var/log/cpapshare.log` and `/var/log/cpapshare.error.log`. To prevent these logs from growing indefinitely, you can set up logrotate to automatically manage them.
+
+Create a logrotate configuration file:
+
+```shell
+sudo tee /etc/logrotate.d/cpapshare << 'EOF'
+/var/log/cpapshare.log /var/log/cpapshare.error.log {
+    maxsize 50M
+    rotate 2
+    compress
+    delaycompress
+    missingok
+    notifempty
+    create 644 root root
+    postrotate
+        systemctl reload-or-restart cpapshare.service > /dev/null 2>&1 || true
+    endscript
+}
+EOF
+```
+
+This configuration:
+- Rotates logs when they exceed 50MB each (keeping total under 100MB for both log files)
+- Keeps 2 old log files (current + 2 rotated = max 150MB total)
+- Compresses old logs to save space
+- Restarts the service after rotation to ensure it writes to the new log file
+
+You can test the logrotate configuration:
+```shell
+sudo logrotate -d /etc/logrotate.d/cpapshare  # dry run
+sudo logrotate -f /etc/logrotate.d/cpapshare  # force rotation for testing
+```
+
 ## Syncing to Your Computer
 
 I recommend using Syncthing - it's perfect for sharing the backup folder with your desktop:

--- a/README.md
+++ b/README.md
@@ -158,40 +158,9 @@ Controls whether to delete the DATALOG directory from the SD card after successf
 
 **Note:** If no `config.json` file exists, the script will use the defaults (`copy_type: "raw"`, `delete_after_copy: false`).
 
-## Log Management
+## Troubleshooting
 
-CPAPShare writes logs to `/var/log/cpapshare.log` and `/var/log/cpapshare.error.log`. To prevent these logs from growing indefinitely, you can set up logrotate to automatically manage them.
-
-Create a logrotate configuration file:
-
-```shell
-sudo tee /etc/logrotate.d/cpapshare << 'EOF'
-/var/log/cpapshare.log /var/log/cpapshare.error.log {
-    maxsize 50M
-    rotate 2
-    compress
-    delaycompress
-    missingok
-    notifempty
-    create 644 root root
-    postrotate
-        systemctl reload-or-restart cpapshare.service > /dev/null 2>&1 || true
-    endscript
-}
-EOF
-```
-
-This configuration:
-- Rotates logs when they exceed 50MB each (keeping total under 100MB for both log files)
-- Keeps 2 old log files (current + 2 rotated = max 150MB total)
-- Compresses old logs to save space
-- Restarts the service after rotation to ensure it writes to the new log file
-
-You can test the logrotate configuration:
-```shell
-sudo logrotate -d /etc/logrotate.d/cpapshare  # dry run
-sudo logrotate -f /etc/logrotate.d/cpapshare  # force rotation for testing
-```
+You can view logs with `sudo journalctl -u cpapshare.service -f`
 
 ## Syncing to Your Computer
 

--- a/README.md
+++ b/README.md
@@ -102,9 +102,7 @@ This adds a polkit config allowing members of the `sudo` group to mount devices.
 The project includes a SystemD service file ([cpapshare.service](./cpapshare.service)). To enable it:
 ```shell
 sudo cp cpapshare.service /etc/systemd/system/cpapshare.service
-sudo systemctl enable cpapshare.service
-sudo systemctl restart cpapshare.service
-sudo systemctl status cpapshare.service
+sudo systemctl enable --now cpapshare.service
 ```
 
 ## Callback on backup completion

--- a/README.md
+++ b/README.md
@@ -99,6 +99,53 @@ systemctl enable cpapshare.service
 The `cpapshare.rb` also has a mechanism to trigger some callback script after the backup is done. You simply need to have a file `post_backup.sh` in the same directory as the cpapshare.rb file.  
 Check example [post_backup.example.sh](./post_backup.example.sh), I'm using it to send a notification to [ntfy.sh](http://ntfy.sh), so I get notified on my phone when the backup is done. Make sure the script is executable.
 
+## Configuration
+
+CPAPShare can be configured using a `config.json` file in the project directory. The configuration is reloaded automatically each time an SD card is inserted, so no service restart is needed when changing settings.
+
+### Configuration Options
+
+Create a `config.json` file with the following options:
+
+```json
+{
+  "copy_type": "raw",
+  "delete_after_copy": false
+}
+```
+
+#### `copy_type`
+Controls how files are copied from the SD card:
+
+- **`"raw"`** (default): Copies all files and directories from the SD card directly to `~/cpapshare-data/`
+- **`"dates"`**: Looks for a `DATALOG` directory, finds the date range (e.g., `20250827` to `20250831`), and creates a backup directory named with the date range (e.g., `20250827-20250831`)
+
+#### `delete_after_copy`
+Controls whether to delete the DATALOG directory from the SD card after successful backup:
+
+- **`false`** (default): Keep all data on the SD card
+- **`true`**: Delete the `DATALOG` directory from the SD card after successful copy (⚠️ **Use with caution!**)
+
+### Example Configurations
+
+**Basic setup (copies everything, keeps original):**
+```json
+{
+  "copy_type": "raw",
+  "delete_after_copy": false
+}
+```
+
+**Date-organized backup with auto-cleanup:**
+```json
+{
+  "copy_type": "dates",
+  "delete_after_copy": true
+}
+```
+
+**Note:** If no `config.json` file exists, the script will use the defaults (`copy_type: "raw"`, `delete_after_copy: false`).
+
 ## Syncing to Your Computer
 
 I recommend using Syncthing - it's perfect for sharing the backup folder with your desktop:

--- a/README.md
+++ b/README.md
@@ -60,16 +60,16 @@ sequenceDiagram
 ## Setting Things Up
 
 1. Flash [Armbian](https://www.armbian.com/) to your Orange Pi's MicroSD card
-2. Edit `/root/.not_logged_in_yet` . ([see Armbian docs](https://docs.armbian.com/User-Guide_Autoconfig/#sample-config-file)) 
-3. SSH into the device: `ssh root@YOUR_DEVICE_IP`
+2. Edit `/root/.not_logged_in_yet`. ([see Armbian docs](https://docs.armbian.com/User-Guide_Autoconfig/#sample-config-file)) (Username must be 'armbian'.)
+3. SSH into the device: `ssh armbian@YOUR_DEVICE_IP`
 4. Update system: 
 ```shell
-sudo apt update && sudo apt full-upgrade --yes && sudo reboot`
+sudo apt update && sudo apt full-upgrade --yes && sudo reboot
 ```
 5. install the dependencies:
 
 ```shell
-sudo apt install curl udisks2 policykit-1-gnome ruby ruby-dbus ruby-optimist
+sudo apt install curl git udisks2 policykit-1-gnome ruby ruby-dbus ruby-optimist
 ```
 
 6. Clone this repository with:

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,4 @@
+{
+  "copy_type": "raw",
+  "delete_after_copy": false
+}

--- a/cpapshare.rb
+++ b/cpapshare.rb
@@ -135,8 +135,8 @@ class UsbBackup
     
     datalog_path = File.join(@mount_point, 'DATALOG')
     unless Dir.exist?(datalog_path)
-      puts "DATALOG directory not found, falling back to raw copy"
-      return copy_raw
+      puts "DATALOG directory not found, skipping copy"
+      return false
     end
 
     # Get all subdirectories in DATALOG and sort them as integers
@@ -146,8 +146,8 @@ class UsbBackup
                    .sort_by(&:to_i)
 
     if date_dirs.empty?
-      puts "No date directories found in DATALOG, falling back to raw copy"
-      return copy_raw
+      puts "No date directories found in DATALOG, skipping copy"
+      return false
     end
 
     first_date = date_dirs.first

--- a/cpapshare.rb
+++ b/cpapshare.rb
@@ -3,12 +3,38 @@
 require 'fileutils'
 require 'optimist'
 require 'dbus'
+require 'json'
 
 BACKUP_DIR = "/home/#{ENV['USER']}/cpapshare-data/".freeze
 POLKIT_RULE_PATH = '/etc/polkit-1/rules.d/10-udisks2.rules'.freeze
 SUDOERS_PATH = '/etc/sudoers.d/cpapshare'.freeze
+CONFIG_FILE = "#{File.dirname File.absolute_path(__FILE__)}/config.json".freeze
 
 class UsbBackup
+  def initialize
+    # Don't load config at startup, load it fresh each time
+  end
+
+  def load_config
+    config = {}
+    if File.exist?(CONFIG_FILE)
+      begin
+        config = JSON.parse(File.read(CONFIG_FILE))
+      rescue JSON::ParserError => e
+        puts "Warning: Invalid JSON in config file, using defaults: #{e.message}"
+        config = {}
+      end
+    end
+    
+    # Set default for copy_type if not present
+    config["copy_type"] ||= "raw"
+    
+    # Set default for delete_after_copy if not present
+    config["delete_after_copy"] = false if config["delete_after_copy"].nil?
+    
+    config
+  end
+
   def wait_for_mount!
     puts 'Wait for device...'
 
@@ -32,8 +58,13 @@ class UsbBackup
           @mount_point = "/tmp/cpapshare_mount_#{Time.now.to_i}"
           Dir.mkdir(@mount_point) unless Dir.exist?(@mount_point)
           
-          # Mount with sudo (configured for NOPASSWD)
-          mount_cmd = "sudo mount #{@device} #{@mount_point}"
+          # Get armbian user ID and group ID for mount ownership
+          armbian_uid = `id -u armbian`.strip
+          armbian_gid = `id -g armbian`.strip
+          
+          # Mount FAT32 filesystem with user ownership for full read/write access
+          mount_cmd = "sudo mount -t vfat -o rw,uid=#{armbian_uid},gid=#{armbian_gid},umask=0000 #{@device} #{@mount_point}"
+          puts "Mounting FAT32 with command: #{mount_cmd}"
           mount_result = `#{mount_cmd} 2>&1`
           if $?.success?
             puts "Successfully mounted #{@device} at #{@mount_point}"
@@ -53,11 +84,147 @@ class UsbBackup
   end
 
   def copy_contents
+    # Reload configuration fresh each time for immediate config changes
+    @config = load_config
+    
+    if File.exist?(CONFIG_FILE)
+      puts "Configuration reloaded from #{CONFIG_FILE}"
+    else
+      puts "Configuration file #{CONFIG_FILE} not found, using defaults"
+    end
+    
+    puts "Configuration:"
+    puts "\tcopy_type: #{@config['copy_type']}"
+    puts "\tdelete_after_copy: #{@config['delete_after_copy']}"
+    
     puts "Copy sdcard contents to #{BACKUP_DIR}"
 
     FileUtils.mkdir_p(BACKUP_DIR) unless Dir.exist?(BACKUP_DIR)
 
-    recursive_copy(@mount_point, BACKUP_DIR)
+    copy_success = false
+    begin
+      case @config['copy_type']
+      when 'dates'
+        copy_success = copy_with_dates
+      else
+        copy_success = copy_raw
+      end
+      
+      # Delete DATALOG directory after successful copy if configured
+      if copy_success && @config['delete_after_copy']
+        delete_datalog_after_copy
+      end
+    rescue => e
+      puts "Error during copy operation: #{e.message}"
+      copy_success = false
+    end
+    
+    copy_success
+  end
+
+  def copy_raw
+    puts "Performing raw copy of all files"
+    begin
+      recursive_copy(@mount_point, BACKUP_DIR)
+      puts "Raw copy completed successfully"
+      return true
+    rescue => e
+      puts "Raw copy failed: #{e.message}"
+      return false
+    end
+  end
+
+  def copy_with_dates
+    puts "Performing dates-based copy"
+    
+    datalog_path = File.join(@mount_point, 'DATALOG')
+    unless Dir.exist?(datalog_path)
+      puts "DATALOG directory not found, falling back to raw copy"
+      return copy_raw
+    end
+
+    # Get all subdirectories in DATALOG and sort them as integers
+    date_dirs = Dir.entries(datalog_path)
+                   .select { |entry| File.directory?(File.join(datalog_path, entry)) && entry != '.' && entry != '..' }
+                   .select { |entry| entry.match?(/^\d+$/) }  # Only numeric directory names
+                   .sort_by(&:to_i)
+
+    if date_dirs.empty?
+      puts "No date directories found in DATALOG, falling back to raw copy"
+      return copy_raw
+    end
+
+    first_date = date_dirs.first
+    last_date = date_dirs.last
+    
+    # Create destination directory name
+    if first_date == last_date
+      dest_dir_name = first_date
+    else
+      dest_dir_name = "#{first_date}-#{last_date}"
+    end
+    
+    dest_path = File.join(BACKUP_DIR, dest_dir_name)
+    puts "Creating backup directory: #{dest_dir_name}"
+    puts "Date range: #{first_date} to #{last_date} (#{date_dirs.length} days)"
+    
+    FileUtils.mkdir_p(dest_path) unless Dir.exist?(dest_path)
+    
+    begin
+      # Copy entire contents of the mount point to the destination
+      recursive_copy(@mount_point, dest_path)
+      puts "Dates-based copy completed successfully"
+      return true
+    rescue => e
+      puts "Dates-based copy failed: #{e.message}"
+      return false
+    end
+  end
+
+  def delete_datalog_after_copy
+    datalog_path = File.join(@mount_point, 'DATALOG')
+    
+    unless Dir.exist?(datalog_path)
+      puts "DATALOG directory not found, skipping deletion"
+      return
+    end
+    
+    # Check if mount point is writable by testing file creation
+    test_file = File.join(@mount_point, ".cpapshare_write_test")
+    begin
+      File.write(test_file, "test")
+      File.delete(test_file) if File.exist?(test_file)
+      puts "Mount point is writable, proceeding with deletion..."
+    rescue => e
+      puts "Mount point is not writable, cannot delete DATALOG: #{e.message}"
+      puts "SD card may be mounted read-only or filesystem doesn't support deletion"
+      return
+    end
+    
+    puts "Deleting DATALOG directory from source after successful copy..."
+    begin
+      # Use Ruby's FileUtils without sudo - this should work if mount is writable
+      FileUtils.rm_rf(datalog_path)
+      
+      # Verify deletion
+      if Dir.exist?(datalog_path)
+        puts "Warning: DATALOG directory still exists after deletion attempt"
+        puts "This may be due to filesystem restrictions or the device being remounted read-only"
+        
+        # Try to understand why deletion failed
+        begin
+          entries = Dir.entries(datalog_path).reject { |e| e == '.' || e == '..' }
+          puts "Directory still contains #{entries.length} items: #{entries.first(3).join(', ')}#{entries.length > 3 ? '...' : ''}"
+        rescue => e
+          puts "Could not read directory contents: #{e.message}"
+        end
+      else
+        puts "DATALOG directory successfully deleted from source"
+      end
+    rescue => e
+      puts "Error deleting DATALOG directory: #{e.message}"
+      puts "This is likely due to filesystem permissions or read-only mount"
+    end
   end
 
   def unmount_device

--- a/cpapshare.rb
+++ b/cpapshare.rb
@@ -121,7 +121,7 @@ class UsbBackup
   def copy_raw
     puts "Performing raw copy of all files"
     begin
-      recursive_copy(@mount_point, BACKUP_DIR)
+      rsync_copy(@mount_point, BACKUP_DIR)
       puts "Raw copy completed successfully"
       return true
     rescue => e
@@ -174,7 +174,7 @@ class UsbBackup
     
     begin
       # Copy entire contents of the mount point to the destination
-      recursive_copy(@mount_point, dest_path)
+      rsync_copy(@mount_point, dest_path)
       puts "Dates-based copy completed successfully"
       return true
     rescue => e
@@ -248,20 +248,21 @@ class UsbBackup
 
   private
 
-  def recursive_copy(source, destination)
-    Dir.foreach(source) do |item|
-      next if ['.', '..'].include?(item)
-
-      source_path = File.join(source, item)
-      dest_path = File.join(destination, item)
-
-      if File.directory?(source_path)
-        FileUtils.mkdir_p(dest_path) unless Dir.exist?(dest_path)
-        recursive_copy(source_path, dest_path)
-      else
-        FileUtils.cp(source_path, dest_path)
-      end
+  def rsync_copy(source, destination)
+    # Ensure destination directory exists
+    FileUtils.mkdir_p(destination) unless Dir.exist?(destination)
+    
+    # Use rsync to copy files, preserving timestamps and only copying changed files
+    cmd = "rsync -ah --update --delete '#{source}/' '#{destination}/'"
+    
+    puts "Running rsync: #{cmd}"
+    success = system(cmd)
+    
+    unless success
+      raise "rsync failed with exit code #{$?.exitstatus}"
     end
+    
+    puts "rsync completed successfully"
   end
 end
 

--- a/cpapshare.rb
+++ b/cpapshare.rb
@@ -6,6 +6,7 @@ require 'dbus'
 
 BACKUP_DIR = "/home/#{ENV['USER']}/cpapshare-data/".freeze
 POLKIT_RULE_PATH = '/etc/polkit-1/rules.d/10-udisks2.rules'.freeze
+SUDOERS_PATH = '/etc/sudoers.d/cpapshare'.freeze
 
 class UsbBackup
   def wait_for_mount!
@@ -27,11 +28,20 @@ class UsbBackup
           # Check if it's a filesystem
           puts 'Device is a filesystem and ready to be mounted!'
 
-          `udisksctl mount -b #{@device}`
-          File.foreach('/proc/mounts') do |line|
-            if line.start_with?(@device)
-              return @mount_point = line.split[1] # Return the mount point
-            end
+          # Create a mount point in /tmp
+          @mount_point = "/tmp/cpapshare_mount_#{Time.now.to_i}"
+          Dir.mkdir(@mount_point) unless Dir.exist?(@mount_point)
+          
+          # Mount with sudo (configured for NOPASSWD)
+          mount_cmd = "sudo mount #{@device} #{@mount_point}"
+          mount_result = `#{mount_cmd} 2>&1`
+          if $?.success?
+            puts "Successfully mounted #{@device} at #{@mount_point}"
+            return @mount_point
+          else
+            puts "Mount failed: #{mount_result.strip}"
+            Dir.rmdir(@mount_point) if Dir.exist?(@mount_point) && Dir.empty?(@mount_point)
+            return nil
           end
         end
       end
@@ -53,7 +63,17 @@ class UsbBackup
   def unmount_device
     puts 'Unmount sdcard'
 
-    `udisksctl unmount -b #{@device}`
+    # Unmount with sudo (configured for NOPASSWD)
+    umount_result = `sudo umount #{@mount_point} 2>&1`
+    if $?.success?
+      puts "Successfully unmounted #{@mount_point}"
+      # Clean up the temporary mount point
+      if @mount_point.start_with?('/tmp/cpapshare_mount_')
+        Dir.rmdir(@mount_point) if Dir.exist?(@mount_point) && Dir.empty?(@mount_point)
+      end
+    else
+      puts "Unmount failed: #{umount_result.strip}"
+    end
   end
 
   def run_callback
@@ -112,8 +132,16 @@ if opts[:install]
     polkit.addRule(function(action, subject) {
         if ((action.id == "org.freedesktop.udisks2.filesystem-mount-system" ||
              action.id == "org.freedesktop.udisks2.filesystem-mount-other-seat" ||
-             action.id == "org.freedesktop.udisks2.filesystem-mount") &&
-            subject.isInGroup("sudo")) {
+             action.id == "org.freedesktop.udisks2.filesystem-mount" ||
+             action.id == "org.freedesktop.udisks2.filesystem-unmount-others") &&
+            (subject.isInGroup("sudo") || subject.isInGroup("plugdev"))) {
+            return polkit.Result.YES;
+        }
+    });
+
+    polkit.addRule(function(action, subject) {
+        if (action.id == "org.freedesktop.udisks2.filesystem-mount" &&
+            subject.user == "armbian") {
             return polkit.Result.YES;
         }
     });
@@ -122,12 +150,26 @@ if opts[:install]
   File.write(POLKIT_RULE_PATH, polkit_rule)
   FileUtils.chmod(0o644, POLKIT_RULE_PATH)
   puts "Polkit rule installed to #{POLKIT_RULE_PATH}"
+  
+  # Create sudoers configuration for mount/unmount permissions
+  sudoers_rule = <<~EOS
+    # Allow armbian user to mount and unmount devices for cpapshare
+    armbian ALL=(ALL) NOPASSWD: /bin/mount, /bin/umount
+  EOS
+  
+  File.write(SUDOERS_PATH, sudoers_rule)
+  FileUtils.chmod(0o440, SUDOERS_PATH)
+  puts "Sudoers rule installed to #{SUDOERS_PATH}"
+  
   # Reload polkit rules
-  warn 'Warning: Failed to reload polkit rules' unless system('systemctl reload polkit')
+  warn 'Warning: Failed to restart polkit' unless system('systemctl restart polkit')
 
 elsif opts[:uninstall]
-  File.delete(POLKIT_RULE_PATH)
-  puts "Polkit rule uninstalled from #{POLKIT_RULE_PATH}"
+  File.delete(POLKIT_RULE_PATH) if File.exist?(POLKIT_RULE_PATH)
+  puts "Polkit rule uninstalled from #{POLKIT_RULE_PATH}" if File.exist?(POLKIT_RULE_PATH)
+  
+  File.delete(SUDOERS_PATH) if File.exist?(SUDOERS_PATH)
+  puts "Sudoers rule uninstalled from #{SUDOERS_PATH}" if File.exist?(SUDOERS_PATH)
 else
   begin
     loop do

--- a/cpapshare.rb
+++ b/cpapshare.rb
@@ -86,7 +86,7 @@ class UsbBackup
     if File.exist?(CONFIG_FILE)
       puts "Configuration reloaded from #{CONFIG_FILE}"
     else
-      puts "Configuration file #{CONFIG_FILE} not found, using defaults"
+      warn "Configuration file #{CONFIG_FILE} not found, using defaults"
     end
     
     puts "Configuration:"

--- a/cpapshare.rb
+++ b/cpapshare.rb
@@ -7,7 +7,6 @@ require 'json'
 
 BACKUP_DIR = "/home/#{ENV['USER']}/cpapshare-data/".freeze
 POLKIT_RULE_PATH = '/etc/polkit-1/rules.d/10-udisks2.rules'.freeze
-SUDOERS_PATH = '/etc/sudoers.d/cpapshare'.freeze
 CONFIG_FILE = "#{File.dirname File.absolute_path(__FILE__)}/config.json".freeze
 
 class UsbBackup
@@ -54,24 +53,21 @@ class UsbBackup
           # Check if it's a filesystem
           puts 'Device is a filesystem and ready to be mounted!'
 
-          # Create a mount point in /tmp
-          @mount_point = "/tmp/cpapshare_mount_#{Time.now.to_i}"
-          Dir.mkdir(@mount_point) unless Dir.exist?(@mount_point)
-          
-          # Get armbian user ID and group ID for mount ownership
-          armbian_uid = `id -u armbian`.strip
-          armbian_gid = `id -g armbian`.strip
-          
-          # Mount FAT32 filesystem with user ownership for full read/write access
-          mount_cmd = "sudo mount -t vfat -o rw,uid=#{armbian_uid},gid=#{armbian_gid},umask=0000 #{@device} #{@mount_point}"
-          puts "Mounting FAT32 with command: #{mount_cmd}"
-          mount_result = `#{mount_cmd} 2>&1`
+          # Use udisksctl to mount the device
+          mount_result = `udisksctl mount -b #{@device}`
           if $?.success?
-            puts "Successfully mounted #{@device} at #{@mount_point}"
-            return @mount_point
+            # Find the mount point from /proc/mounts
+            File.foreach('/proc/mounts') do |line|
+              if line.start_with?(@device)
+                @mount_point = line.split[1] # Get the mount point
+                puts "Successfully mounted #{@device} at #{@mount_point}"
+                return @mount_point
+              end
+            end
+            puts "Mount succeeded but could not find mount point"
+            return nil
           else
             puts "Mount failed: #{mount_result.strip}"
-            Dir.rmdir(@mount_point) if Dir.exist?(@mount_point) && Dir.empty?(@mount_point)
             return nil
           end
         end
@@ -230,14 +226,10 @@ class UsbBackup
   def unmount_device
     puts 'Unmount sdcard'
 
-    # Unmount with sudo (configured for NOPASSWD)
-    umount_result = `sudo umount #{@mount_point} 2>&1`
+    # Use udisksctl to unmount the device
+    umount_result = `udisksctl unmount -b #{@device}`
     if $?.success?
-      puts "Successfully unmounted #{@mount_point}"
-      # Clean up the temporary mount point
-      if @mount_point.start_with?('/tmp/cpapshare_mount_')
-        Dir.rmdir(@mount_point) if Dir.exist?(@mount_point) && Dir.empty?(@mount_point)
-      end
+      puts "Successfully unmounted #{@device}"
     else
       puts "Unmount failed: #{umount_result.strip}"
     end
@@ -299,16 +291,8 @@ if opts[:install]
     polkit.addRule(function(action, subject) {
         if ((action.id == "org.freedesktop.udisks2.filesystem-mount-system" ||
              action.id == "org.freedesktop.udisks2.filesystem-mount-other-seat" ||
-             action.id == "org.freedesktop.udisks2.filesystem-mount" ||
-             action.id == "org.freedesktop.udisks2.filesystem-unmount-others") &&
-            (subject.isInGroup("sudo") || subject.isInGroup("plugdev"))) {
-            return polkit.Result.YES;
-        }
-    });
-
-    polkit.addRule(function(action, subject) {
-        if (action.id == "org.freedesktop.udisks2.filesystem-mount" &&
-            subject.user == "armbian") {
+             action.id == "org.freedesktop.udisks2.filesystem-mount") &&
+            subject.isInGroup("sudo")) {
             return polkit.Result.YES;
         }
     });
@@ -317,26 +301,12 @@ if opts[:install]
   File.write(POLKIT_RULE_PATH, polkit_rule)
   FileUtils.chmod(0o644, POLKIT_RULE_PATH)
   puts "Polkit rule installed to #{POLKIT_RULE_PATH}"
-  
-  # Create sudoers configuration for mount/unmount permissions
-  sudoers_rule = <<~EOS
-    # Allow armbian user to mount and unmount devices for cpapshare
-    armbian ALL=(ALL) NOPASSWD: /bin/mount, /bin/umount
-  EOS
-  
-  File.write(SUDOERS_PATH, sudoers_rule)
-  FileUtils.chmod(0o440, SUDOERS_PATH)
-  puts "Sudoers rule installed to #{SUDOERS_PATH}"
-  
   # Reload polkit rules
   warn 'Warning: Failed to restart polkit' unless system('systemctl restart polkit')
 
 elsif opts[:uninstall]
   File.delete(POLKIT_RULE_PATH) if File.exist?(POLKIT_RULE_PATH)
   puts "Polkit rule uninstalled from #{POLKIT_RULE_PATH}" if File.exist?(POLKIT_RULE_PATH)
-  
-  File.delete(SUDOERS_PATH) if File.exist?(SUDOERS_PATH)
-  puts "Sudoers rule uninstalled from #{SUDOERS_PATH}" if File.exist?(SUDOERS_PATH)
 else
   begin
     loop do

--- a/cpapshare.rb
+++ b/cpapshare.rb
@@ -305,8 +305,10 @@ if opts[:install]
   warn 'Warning: Failed to restart polkit' unless system('systemctl restart polkit')
 
 elsif opts[:uninstall]
-  File.delete(POLKIT_RULE_PATH) if File.exist?(POLKIT_RULE_PATH)
-  puts "Polkit rule uninstalled from #{POLKIT_RULE_PATH}" if File.exist?(POLKIT_RULE_PATH)
+  if File.exist?(POLKIT_RULE_PATH)
+    File.delete(POLKIT_RULE_PATH)
+    puts "Polkit rule uninstalled from #{POLKIT_RULE_PATH}"
+  end
 else
   begin
     loop do

--- a/cpapshare.rb
+++ b/cpapshare.rb
@@ -153,11 +153,17 @@ class UsbBackup
     first_date = date_dirs.first
     last_date = date_dirs.last
     
+    # Helper method to format date from YYYYMMDD to YYYY.MM.DD
+    def format_date(date_str)
+      return date_str unless date_str.length == 8 && date_str.match?(/^\d{8}$/)
+      "#{date_str[0..3]}.#{date_str[4..5]}.#{date_str[6..7]}"
+    end
+    
     # Create destination directory name
     if first_date == last_date
-      dest_dir_name = first_date
+      dest_dir_name = format_date(first_date)
     else
-      dest_dir_name = "#{first_date}-#{last_date}"
+      dest_dir_name = "#{format_date(first_date)}-#{format_date(last_date)}"
     end
     
     dest_path = File.join(BACKUP_DIR, dest_dir_name)

--- a/cpapshare.service
+++ b/cpapshare.service
@@ -6,12 +6,9 @@ Wants=udisks2.service
 [Service]
 Type=simple
 User=armbian
-Group=armbian
 ExecStart=/usr/bin/ruby /home/armbian/cpapshare/cpapshare.rb
 Restart=always
 RestartSec=5
-StandardOutput=append:/var/log/cpapshare.log
-StandardError=append:/var/log/cpapshare.error.log
 
 [Install]
 WantedBy=multi-user.target

--- a/cpapshare.service
+++ b/cpapshare.service
@@ -6,6 +6,7 @@ Wants=udisks2.service
 [Service]
 Type=simple
 User=armbian
+Group=armbian
 ExecStart=/usr/bin/ruby /home/armbian/cpapshare/cpapshare.rb
 Restart=always
 RestartSec=5


### PR DESCRIPTION
## Improvements:

1) Added `git` to the dependency install command

2) Created a `.gitignore`

3) Updated readme to mention that the username must be 'armbian'. I wasn't aware of this and created a user with a different name. This caused me a lot of troubleshooting until I realized that the user 'armbian' is hard-coded in the service.

4) Added a `copy_type` option with the default value of `raw` to perform a raw copy of the sd card content as it always has been. You can change it to `dates` and it will organize each import. See readme for more details.

5) Added a `delete_after_copy` with the default value of `false` to keep the sd card contents as it always has been. You can change it to `true` and it will delete the DATALOG from the sd card after import. See readme for more details.

6) Add table of contents and troubleshooting sections to readme.

7) Added steps to restart the service after enable (when following your original steps, enabling the service does not start it so it was not working).